### PR TITLE
Configure GH Pages deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,26 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./build
+


### PR DESCRIPTION
## Summary
- deploy site to `gh-pages` branch on every push to `main`

## Testing
- `npm install`
- `npm run build`
- `npm run typecheck`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846701e7eb88328b8da940745161dbd