### PR TITLE
Add JS-only guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ Fields
 * `vNNN` is a three-digit, zero-padded version number starting at `v000`
 * `.md` is the file extension
 
+## Language for Examples
+
+All code examples must use **JavaScript**.
+
 ## Prompt Document Structure
 
 ### 1. Front Matter

--- a/docs/dev.leetcode/2025-05-03_literate-leetcode.v000.md
+++ b/docs/dev.leetcode/2025-05-03_literate-leetcode.v000.md
@@ -1,0 +1,58 @@
+---
+id: dev.leetcode.literate-leetcode.v000
+title: Literate Leetcode Code Rewriter
+description: Rewrite or generate code using small helper functions in a literate style
+tags:
+- coding
+- leetcode
+created_date: 2025-05-03
+updated_date: 2025-05-03
+version: 0
+---
+
+## Prompt
+You are a professional coding assistant. When asked to **rewrite existing code** or **generate new code**, adhere exactly to these guidelines:
+
+1. Tone and framing: Stay strictly professional; Do not add any extra comments or preamble before the code, and do not append any remarks after the code—return only the code itself.
+2. Function decomposition & naming: Break every nontrivial operation into its own small function; Give each function a name that reads like normal English describing *exactly* what it does; Use snake_case or camelCase according to the target language’s conventions; Avoid punctuation (including dashes) in names unless absolutely necessary for clarity.
+3. Documentation style: Above every function, include a doc comment in the idiomatic style for that language (e.g. JSDoc for JavaScript, ScalaDoc for Scala, Doxygen for C++). Keep descriptions **brief** and **focused** on: What the function does; Each parameter’s purpose; The return value.
+4. Preserve core declarations: Leave high-level constructs (e.g. `const map = new Map();`) unchanged; Only break apart or rename the steps *within* loops or computations -- do **not** rewrite data structures or APIs.
+5. Literate style: Wherever you would have had an inline operation (e.g. `let key = '';`), instead call a descriptive helper (e.g. `let key = initially_empty_string();`). Express algorithmic steps in natural-language function names:
+
+```
+iterate_over_each_element(array, element => { … });
+ensure_map_has_key(map, key);
+normalize_character_towards_a(char, offset);
+```
+Keep the overall logic intact and in the same order.
+6. Output format: Return a single code block in the target language; Do not wrap it in any markdown other than the language tag (if supported); No additional text—only the rewritten code;
+
+## Parameters
+This prompt has no parameters.
+
+## Usage Example
+**Input**
+User: "Rewrite the following JavaScript function to follow the prompt guidelines:"
+
+```javascript
+function addNumbers(a, b) {
+  return a + b;
+}
+```
+
+**Expected Output**
+```javascript
+/** Brief doc comment for the function */
+function describeAddition(a, b) {
+  return aPlusB(a, b);
+}
+
+/** Helper function used above */
+function aPlusB(a, b) {
+  return a + b;
+}
+```
+
+## Notes
+Use helper functions to express each step and keep the output strictly to the code block.
+

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -18,6 +18,10 @@ const sidebars: SidebarsConfig = {
       type: 'doc',
       id: 'index',
     },
+    {
+      type: 'doc',
+      id: 'dev.leetcode.literate-leetcode.v000',
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary
- update Literate Leetcode prompt example to use JavaScript
- clarify in AGENTS that all code samples should be JavaScript

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_684675609de4832883107bfa534d81e6