### PR TITLE
Fix GH Pages deployment permissions

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,5 +1,9 @@
 name: Deploy to GitHub Pages
 
+# Grant write access so the action can push to the `gh-pages` branch.
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- update deploy workflow to grant write access

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68467edce470832893d924abc7081730