### PR TITLE
Add project URL to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+## 2025-06-09 Added project URL to README
+
+**Task Overview**
+Added a link to the hosted project in the README.
+
+**Context**
+The README did not include a direct URL to the live site, making it harder for users to find.
+
+**Thought Process**
+Decided to place the URL in a dedicated section near the top so visitors can quickly access the deployed site.
+
+**Chosen Solution**
+Added a "Project URL" section to the README pointing to the GitHub Pages deployment.
+
+**Implementation**
+- Updated `README.md` with the new section.
+- Created `CHANGELOG.md` documenting this change.
+
+**Verification**
+Reviewed the README to confirm the link is present and correctly formatted.
+
+**Deployment**
+No deployment steps are necessary; this is documentation only.
+
+**Impact Summary**
+Users now have immediate access to the live project via the README link.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This site is built using [Docusaurus](https://docusaurus.io/) and will host a collection of useful prompts for language models.
 
+## Project URL
+
+You can view the site at [https://atarashiineko.github.io/toy_projects/](https://atarashiineko.github.io/toy_projects/).
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## 2025-06-09 Added project URL to README

**Task Overview**
Added the live project link to the README for quick access.

**Context**
The repository's documentation had no direct URL to the deployed site.

**Thought Process**
Placing the URL early in the README ensures visitors see it immediately.

**Chosen Solution**
Introduced a "Project URL" section referencing the GitHub Pages deployment.

**Implementation**
- Updated `README.md` with the new link.
- Created `CHANGELOG.md` detailing this change.

**Verification**
- `npm run typecheck`
- `npm run build`

**Deployment**
No deployment actions required.

**Impact Summary**
Documentation now directs users to the live site, improving usability.

------
https://chatgpt.com/codex/tasks/task_e_684682bcfd748328962017e6252e97e7