### PR TITLE
Add pixel art thermal printer prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+
+## 2025-06-09 Added thermal printer pixel art prompt
+
+**Task Overview**
+Created a new prompt for generating pixelated images in thermal printer style.
+
+**Context**
+The prompt collection lacked guidance on producing black-and-white pixel art images.
+
+**Thought Process**
+Followed repository conventions to place the prompt under a new visual category.
+
+**Chosen Solution**
+Added a markdown file containing detailed instructions for creating the effect.
+
+**Implementation**
+- Created `docs/visual.pixel-art/2025-06-09_thermal-printer-pixel.v000.md`.
+- Updated `CHANGELOG.md` with this entry.
+
+**Verification**
+Checked the file to ensure formatting and front matter are correct.
+
+**Deployment**
+No deployment steps are required for this documentation update.
+
+**Impact Summary**
+Expands the repository's prompt library with a new pixel-art style guide.
 ## 2025-06-09 Added project URL to README
 
 **Task Overview**

--- a/docs/visual.pixel-art/2025-06-09_thermal-printer-pixel.v000.md
+++ b/docs/visual.pixel-art/2025-06-09_thermal-printer-pixel.v000.md
@@ -1,0 +1,46 @@
+---
+id: visual.pixel-art.thermal-printer-pixel.v000
+title: Pixelated Thermal Printer Style
+description: Render images as coarse black-and-white pixel art on a uniform grid
+tags:
+- pixel-art
+- monochrome
+created_date: 2025-06-09
+updated_date: 2025-06-09
+version: 0
+---
+
+## Prompt
+Create image. Generate a pixelated, black-and-white rendition of the subject in this photo as if printed on a thermal printer. Represent all details using square pixels arranged on a uniform grid, with each pixel rendered as pure black or pure white only.
+Translate contours into blocky, stair-step edges by approximating curves with pixel clusters five to seven pixels wide, ensuring consistent pixel dimensions throughout.
+Exaggerate proportions so the head occupies forty to fifty percent of the total figure height, with torso and limbs occupying the remaining half; depict these regions as contiguous pixel masses without intermediate shades.
+Render the neck as a short, two-pixel-wide column connecting broad, slightly tapered shoulders to the oversized head.
+Form arms and legs as thick, rectangular pixel columns four to six pixels across, omitting joint articulation except as implied by abrupt pixel angle changes.
+Depict hands with four mitten-like pixel shapes each occupying a four-by-four pixel area; define fingers as smooth blocks of pixels without individual knuckle detail.
+In the face, place large circular eyes approximated by eight to ten black pixels forming a near-circle whose diameter is one-quarter of the head height; insert a single central white pixel for the pupil highlight.
+Render eyebrows as pixel blocks two to three pixels high following the brow arc, tilting them slightly upward toward the outer edges by shifting pixel positions diagonally.
+Design the nose as a single two-pixel-wide, three-pixel-high cluster centered just below the eye line, shaped like a rounded block without nostril indication.
+Depict the mouth as a curved row of black pixels in the lower third of the face, extending six to eight pixels wide with upturned ends to create a joyful, friendly expression.
+Indicate cheeks by adding two three-pixel clusters of black pixels on either side of the face below the eye line to suggest blush spots; these clusters should be spaced at least five pixels from the mouth to avoid overlap.
+If facial hair appears, represent it as a contiguous black pixel block broken into a few rounded clusters with a scalloped bottom edge by selectively removing pixels to create curves.
+Render hair or facial hair in solid black pixel masses divided into large, rounded tufts; form the top-of-head hairline as a series of pixel peaks two to three pixels high.
+For clothing and accessories, use solid black pixel regions outlined by a one-pixel-thick border of white to distinguish edges; select one region per garment without introducing shading.
+Suggest folds or creases by omitting pixels to create narrow white lines one pixel wide; place these lines at logical angles beneath shoulders or between limbs and torso.
+Render shadows only as blocks of black pixels directly beneath the chin, brow, and garment folds—no dithered or grayed patterns.
+Design decorative elements such as emblems, belts, or handles using simple geometric pixel shapes (squares, rectangles, straight lines) with each shape at least three pixels wide.
+If a repeating pattern is needed, draw it with thin lines of white pixels within a black field, keeping all pattern lines uniform in width and separated by at least two pixels.
+Set the background to solid white with no additional textures or gradients.
+Ensure the final result is distinctly low-resolution, bold, and blocky, with pure black and white pixels forming simple, pixel-art forms that evoke a thermal-printer aesthetic.
+
+## Parameters
+- `subject_photo`: image or description of the subject to transform
+
+## Usage Example
+**Input**
+User: "Generate a thermal printer pixel drawing of a friendly dog."
+
+**Expected Output**
+A blocky black-and-white pixel art dog with a large head occupying half the height, thick rectangular limbs, and simplified facial features.
+
+## Notes
+This prompt is designed for visual transformation tasks. It exaggerates features for a stylized, coarse pixel aesthetic and uses only solid black and white.


### PR DESCRIPTION
## 2025-06-09 Change title

**Task Overview**
Added a pixelated thermal printer style prompt for image transformations.

**Context**
The prompt library lacked guidance for black-and-white pixel art generation.

**Thought Process**
Analyzed repository conventions and placed the prompt in a new visual category.

**Chosen Solution**
Created a new markdown file with detailed instructions and updated CHANGELOG.

**Implementation**
- Added `docs/visual.pixel-art/2025-06-09_thermal-printer-pixel.v000.md`.
- Updated `CHANGELOG.md` with an entry describing the addition.

**Verification**
Checked formatting and ran `npm run typecheck` (failed due to missing modules).

**Deployment**
No deployment necessary for documentation updates.

**Impact Summary**
Introduces a new prompt expanding the prompt library to include pixelated image style guidance.

------
https://chatgpt.com/codex/tasks/task_e_6846844d50b4832883fd7a6fcc51c12c